### PR TITLE
feat(sidebar): add slash command autocomplete

### DIFF
--- a/src/acp.rs
+++ b/src/acp.rs
@@ -43,12 +43,23 @@ pub enum AgentEvent {
     Cancelled,
     /// Agent or connection error.
     Error(String),
+    /// Agent sent updated list of available slash commands.
+    AvailableCommands(Vec<CommandInfo>),
 }
 
 /// A prompt with optional image attachments.
 pub struct PromptMessage {
     pub text: String,
     pub images: Vec<(String, String)>, // (base64_data, mime_type)
+}
+
+/// Simplified representation of an ACP available command for the UI.
+#[derive(Debug, Clone)]
+pub struct CommandInfo {
+    pub name: String,
+    pub description: String,
+    /// Optional input hint (e.g. "describe what to search for").
+    pub hint: Option<String>,
 }
 
 /// Minimal Client impl — handles streaming text chunks and auto-approves permissions.
@@ -185,6 +196,25 @@ impl acp::Client for BrowserClient {
                     status,
                     raw_output: upd.fields.raw_output.clone(),
                 });
+                (self.wake)();
+            }
+            acp::SessionUpdate::AvailableCommandsUpdate(update) => {
+                let commands: Vec<CommandInfo> = update
+                    .available_commands
+                    .into_iter()
+                    .map(|cmd| {
+                        let hint = cmd.input.and_then(|inp| match inp {
+                            acp::AvailableCommandInput::Unstructured(u) => Some(u.hint),
+                            _ => None,
+                        });
+                        CommandInfo {
+                            name: cmd.name,
+                            description: cmd.description,
+                            hint,
+                        }
+                    })
+                    .collect();
+                let _ = self.tx.send(AgentEvent::AvailableCommands(commands));
                 (self.wake)();
             }
             _ => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1933,6 +1933,16 @@ fn main() {
                             "window.__toolUpdate && window.__toolUpdate(`{eid}`,`{etitle}`,`{estatus}`,{raw_output_json})"
                         ));
                     }
+                    acp::AgentEvent::AvailableCommands(commands) => {
+                        let json: Vec<serde_json::Value> = commands.iter().map(|c| {
+                            serde_json::json!({"name": c.name, "description": c.description, "hint": c.hint})
+                        }).collect();
+                        let json_str = serde_json::to_string(&json).unwrap_or_else(|_| "[]".into());
+                        let escaped = webview_utils::escape_js_template(&json_str);
+                        let _ = sidebar_wv.evaluate_script(&format!(
+                            "window.__setAvailableCommands && window.__setAvailableCommands(`{escaped}`)"
+                        ));
+                    }
                     acp::AgentEvent::Done => {
                         let _ = sidebar_wv.evaluate_script(
                             "window.__setThinking && window.__setThinking(false)"

--- a/src/sidebar_html.rs
+++ b/src/sidebar_html.rs
@@ -833,6 +833,72 @@ pub fn html() -> String {
   }
   .cmd-item.active .cmd-desc { color: rgba(255,255,255,0.75); }
 
+  /* ── Command output card ──────────────────────────────────────────── */
+  .cmd-output {
+    font-size: 12px;
+    line-height: 1.5;
+  }
+  .cmd-output-header {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--accent);
+    margin-bottom: 6px;
+  }
+  .cmd-output-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  .cmd-output-table tr {
+    border-bottom: 1px solid var(--divider);
+  }
+  .cmd-output-table tr:last-child {
+    border-bottom: none;
+  }
+  .cmd-output-key {
+    padding: 3px 8px 3px 0;
+    color: var(--text-secondary);
+    font-size: 11px;
+    white-space: nowrap;
+    vertical-align: top;
+    width: 1%;
+  }
+  .cmd-output-val {
+    padding: 3px 0;
+    color: var(--text-primary);
+    font-size: 12px;
+    word-break: break-word;
+  }
+  .cmd-output-val.null { color: var(--text-tertiary); font-style: italic; }
+  .cmd-output-val.bool-true { color: #34c759; }
+  .cmd-output-val.bool-false { color: var(--text-tertiary); }
+  .cmd-output-val.number { font-variant-numeric: tabular-nums; }
+  .cmd-output-nested {
+    margin: 2px 0;
+    padding: 4px 0 4px 8px;
+    border-left: 2px solid var(--divider);
+    font-size: 11px;
+  }
+  .cmd-output-list {
+    margin: 0;
+    padding-left: 16px;
+  }
+  .cmd-output-list li {
+    margin: 1px 0;
+    font-size: 12px;
+  }
+  .cmd-output-single-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .cmd-output-list-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-secondary);
+  }
+
   #input-row {
     display: flex;
     align-items: center;
@@ -1828,10 +1894,86 @@ pub fn html() -> String {
     return btn;
   }
 
+  // ── Command output renderer ──────────────────────────────────────────
+  function tryParseCommandJson(raw) {
+    var trimmed = raw.trim();
+    if (trimmed.charAt(0) !== '{') return null;
+    try {
+      var obj = JSON.parse(trimmed);
+      if (obj && typeof obj === 'object' && obj.command_type) return obj;
+    } catch(e) {}
+    return null;
+  }
+
+  function formatLabel(key) {
+    return key.replace(/_/g, ' ');
+  }
+
+  function renderCommandValue(val) {
+    if (val === null || val === undefined) return '<span class="null">none</span>';
+    if (typeof val === 'boolean') return '<span class="bool-' + val + '">' + val + '</span>';
+    if (typeof val === 'number') return '<span class="number">' + val + '</span>';
+    if (typeof val === 'string') return escapeHtml(val);
+    if (Array.isArray(val)) {
+      if (val.length === 0) return '<span class="null">none</span>';
+      if (val.every(function(v) { return typeof v === 'string' || typeof v === 'number'; })) {
+        var ul = '<ul class="cmd-output-list">';
+        for (var i = 0; i < val.length; i++) ul += '<li>' + escapeHtml(String(val[i])) + '</li>';
+        return ul + '</ul>';
+      }
+      return '<div class="cmd-output-nested">' + escapeHtml(JSON.stringify(val, null, 2)) + '</div>';
+    }
+    if (typeof val === 'object') {
+      return '<div class="cmd-output-nested">' + renderCommandTable(val) + '</div>';
+    }
+    return escapeHtml(String(val));
+  }
+
+  function renderCommandTable(obj) {
+    var html = '<table class="cmd-output-table">';
+    for (var key in obj) {
+      if (!obj.hasOwnProperty(key)) continue;
+      html += '<tr><td class="cmd-output-key">' + escapeHtml(formatLabel(key)) + '</td>';
+      html += '<td class="cmd-output-val">' + renderCommandValue(obj[key]) + '</td></tr>';
+    }
+    return html + '</table>';
+  }
+
+  function renderCommandOutput(obj) {
+    var cmdType = obj.command_type;
+    var rest = {};
+    for (var key in obj) {
+      if (key === 'command_type') continue;
+      rest[key] = obj[key];
+    }
+    var keys = Object.keys(rest);
+    var body;
+    if (keys.length === 1 && Array.isArray(rest[keys[0]])) {
+      var k = keys[0];
+      var arr = rest[k];
+      body = '<div class="cmd-output-single-list">' +
+        '<div class="cmd-output-list-label">' + escapeHtml(formatLabel(k)) + ':</div>' +
+        renderCommandValue(arr) +
+        '</div>';
+    } else {
+      body = renderCommandTable(rest);
+    }
+    return '<div class="cmd-output">' +
+      '<div class="cmd-output-header">/' + escapeHtml(cmdType) + '</div>' +
+      body +
+      '</div>';
+  }
+
   // Called once Done arrives — stores raw, appends copy btn, collapses if tall
   function finishAgentBubble(bubble, rawText, toolCount, details) {
     const wrap = bubble.closest('.msg');
     wrap.dataset.raw = rawText;
+
+    // Render structured command output if response is JSON with command_type
+    var cmdObj = tryParseCommandJson(rawText);
+    if (cmdObj) {
+      bubble.innerHTML = renderCommandOutput(cmdObj);
+    }
 
     // Show tool count in header if any tools were used
     if (toolCount > 0) {
@@ -1914,7 +2056,8 @@ pub fn html() -> String {
       clearActivity();
     }
     currentAgentRaw += text;
-    currentAgentBubble.innerHTML = renderMd(currentAgentRaw);
+    var cmdObj = tryParseCommandJson(currentAgentRaw);
+    currentAgentBubble.innerHTML = cmdObj ? renderCommandOutput(cmdObj) : renderMd(currentAgentRaw);
     scrollToBottom();
   };
 

--- a/src/sidebar_html.rs
+++ b/src/sidebar_html.rs
@@ -781,7 +781,57 @@ pub fn html() -> String {
     display: flex;
     flex-direction: column;
     gap: 6px;
+    position: relative;
   }
+
+  /* ── Slash command dropdown ─────────────────────────────────────────── */
+  #cmd-dropdown {
+    display: none;
+    position: absolute;
+    bottom: 100%;
+    left: 4px; right: 4px;
+    margin-bottom: 2px;
+    max-height: 200px;
+    overflow-y: auto;
+    background: var(--glass-solid);
+    border: 1px solid var(--glass-border);
+    border-radius: 10px;
+    box-shadow: var(--glass-shadow);
+    z-index: 10;
+    padding: 4px 0;
+  }
+  #cmd-dropdown.visible { display: block; }
+  #cmd-dropdown::-webkit-scrollbar { width: 3px; }
+  #cmd-dropdown::-webkit-scrollbar-thumb { background: var(--scrollbar); border-radius: 2px; }
+
+  .cmd-item {
+    padding: 6px 10px;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+  .cmd-item.active {
+    background: var(--accent);
+    color: #fff;
+  }
+  .cmd-item:hover:not(.active) {
+    background: var(--input-border);
+  }
+  .cmd-name {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+  .cmd-item.active .cmd-name { color: #fff; }
+  .cmd-desc {
+    font-size: 11px;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .cmd-item.active .cmd-desc { color: rgba(255,255,255,0.75); }
 
   #input-row {
     display: flex;
@@ -1335,6 +1385,7 @@ pub fn html() -> String {
 
   <!-- Input -->
   <div id="input-area">
+    <div id="cmd-dropdown"></div>
     <div id="input-row">
       <button id="new-session-btn" title="New session" aria-label="New session">
         <svg width="13" height="13" viewBox="0 0 16 16" fill="none">
@@ -1504,6 +1555,8 @@ pub fn html() -> String {
     thinking.innerHTML = '';
     currentAgentBubble = null;
     currentAgentRaw = '';
+    availableCommands = [];
+    hideCmdDropdown();
   };
 
   // ── Status ──────────────────────────────────────────────────────────────
@@ -1514,11 +1567,122 @@ pub fn html() -> String {
   window.__setConnecting = function() {
     dot.className = 'dot connecting';
     statusTxt.textContent = 'connecting';
+    availableCommands = [];
+    hideCmdDropdown();
   };
   window.__setError = function() {
     dot.className = 'dot error';
     statusTxt.textContent = 'error';
   };
+
+  // ── Slash commands ──────────────────────────────────────────────────────
+  var availableCommands = [];
+  var cmdDropdown = document.getElementById('cmd-dropdown');
+  var cmdActiveIdx = 0;
+  var cmdFiltered = [];
+  var cmdVisible = false;
+
+  window.__setAvailableCommands = function(json) {
+    try { availableCommands = JSON.parse(json); } catch(e) { availableCommands = []; }
+  };
+
+  function showCmdDropdown(filter) {
+    var lower = filter.toLowerCase();
+    cmdFiltered = availableCommands.filter(function(c) {
+      return c.name.toLowerCase().indexOf(lower) === 0;
+    });
+    if (cmdFiltered.length === 0) { hideCmdDropdown(); return; }
+    cmdActiveIdx = 0;
+    renderCmdDropdown();
+    cmdDropdown.classList.add('visible');
+    cmdVisible = true;
+  }
+
+  function hideCmdDropdown() {
+    cmdDropdown.classList.remove('visible');
+    cmdVisible = false;
+    cmdFiltered = [];
+    cmdActiveIdx = 0;
+  }
+
+  function renderCmdDropdown() {
+    cmdDropdown.innerHTML = '';
+    for (var i = 0; i < cmdFiltered.length; i++) {
+      var c = cmdFiltered[i];
+      var div = document.createElement('div');
+      div.className = 'cmd-item' + (i === cmdActiveIdx ? ' active' : '');
+      var nameEl = document.createElement('div');
+      nameEl.className = 'cmd-name';
+      nameEl.textContent = '/' + c.name;
+      var descEl = document.createElement('div');
+      descEl.className = 'cmd-desc';
+      descEl.textContent = c.description;
+      div.appendChild(nameEl);
+      div.appendChild(descEl);
+      (function(idx) {
+        div.addEventListener('mousedown', function(e) {
+          e.preventDefault();
+          selectCmd(idx);
+        });
+        div.addEventListener('mouseenter', function() {
+          cmdActiveIdx = idx;
+          updateCmdActive();
+        });
+      })(i);
+      cmdDropdown.appendChild(div);
+    }
+  }
+
+  function updateCmdActive() {
+    var items = cmdDropdown.querySelectorAll('.cmd-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', i === cmdActiveIdx);
+    }
+    if (items[cmdActiveIdx]) items[cmdActiveIdx].scrollIntoView({ block: 'nearest' });
+  }
+
+  function selectCmd(idx) {
+    var cmd = cmdFiltered[idx];
+    if (!cmd) return;
+    input.value = '/' + cmd.name + ' ';
+    if (cmd.hint) { input.placeholder = cmd.hint; }
+    hideCmdDropdown();
+    input.focus();
+    input.style.height = 'auto';
+    input.style.height = Math.min(input.scrollHeight, 120) + 'px';
+    updateSendBtn();
+  }
+
+  // Capture-phase keydown: intercept arrow/enter/tab/escape when dropdown is visible
+  input.addEventListener('keydown', function(e) {
+    if (!cmdVisible) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault(); e.stopPropagation();
+      if (cmdActiveIdx < cmdFiltered.length - 1) cmdActiveIdx++;
+      updateCmdActive();
+      return;
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault(); e.stopPropagation();
+      if (cmdActiveIdx > 0) cmdActiveIdx--;
+      updateCmdActive();
+      return;
+    }
+    if (e.key === 'Enter' || e.key === 'Tab') {
+      e.preventDefault(); e.stopPropagation();
+      selectCmd(cmdActiveIdx);
+      return;
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault(); e.stopPropagation();
+      hideCmdDropdown();
+      return;
+    }
+  }, true);
+
+  input.addEventListener('blur', function() {
+    setTimeout(hideCmdDropdown, 150);
+  });
 
   // ── Agent chip ──────────────────────────────────────────────────────────
   const agentChip      = document.getElementById('agent-chip');
@@ -2147,6 +2311,7 @@ pub fn html() -> String {
     const docs = pendingDocs.slice();
     if (!text && !images.length && !docs.length) return;
     input.value = '';
+    input.placeholder = 'Ask Octopus\u2026';
     input.style.height = 'auto';
     pendingImages = [];
     pendingDocs = [];
@@ -2204,6 +2369,19 @@ pub fn html() -> String {
     input.style.height = 'auto';
     input.style.height = Math.min(input.scrollHeight, 120) + 'px';
     updateSendBtn();
+
+    var val = input.value;
+    if (!val) { input.placeholder = 'Ask Octopus\u2026'; }
+    if (val.charAt(0) === '/' && availableCommands.length > 0) {
+      var spaceIdx = val.indexOf(' ');
+      if (spaceIdx === -1) {
+        showCmdDropdown(val.substring(1));
+      } else {
+        hideCmdDropdown();
+      }
+    } else {
+      hideCmdDropdown();
+    }
   });
 
   // Hook into __setThinking to drain queue when agent becomes free


### PR DESCRIPTION
- Expose available slash commands to UI
- Add dropdown UI with CSS styling for command items
- Implement keyboard navigation: Arrow keys, Enter, Tab, Escape
- Display commands with name and description
- Show dropdown when user types "/" in input field
- Reset commands and hide dropdown on session clear or connect