### PR TITLE
feat(acp): implement persistent chat session history

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -223,6 +223,79 @@ fn ai_prompt_history_path() -> PathBuf {
         .join("ai_prompt_history.json")
 }
 
+// ── ACP chat history persistence ──────────────────────────────────────────────
+// Persists every assistant session (id, title, tag, optional ACP resume id) and
+// its message log (user prompts, agent responses, errors) so the sidebar can
+// be restored verbatim across browser restarts. Tool details and inline images
+// are intentionally NOT persisted — they bloat the file and can't be replayed
+// faithfully (durations are stale, tool buttons are inert after restart).
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AcpMessage {
+    /// "user" | "agent" | "error"
+    pub role: String,
+    /// Raw text. Markdown for agent, plain otherwise.
+    pub text: String,
+    /// Unix epoch milliseconds at the time the message was committed.
+    #[serde(default)]
+    pub ts: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AcpSessionSnapshot {
+    pub id: u64,
+    pub title: String,
+    pub tag: String,
+    /// ACP-protocol session id reported by the agent on Connected. Passed back
+    /// as `--resume <id>` on next launch so the agent restores its in-memory
+    /// conversation context. None if the agent never connected successfully.
+    #[serde(default)]
+    pub acp_session_id: Option<String>,
+    #[serde(default)]
+    pub messages: Vec<AcpMessage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AcpHistory {
+    pub sessions: Vec<AcpSessionSnapshot>,
+    /// Last-active session id. Restored as the foreground session.
+    #[serde(default)]
+    pub active_id: u64,
+}
+
+pub fn save_acp_history(history: &AcpHistory) {
+    let path = acp_history_path();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let tmp = path.with_extension("json.tmp");
+    match serde_json::to_string(history) {
+        Ok(s) => {
+            if let Err(e) = fs::write(&tmp, &s) {
+                tracing::warn!(error = %e, "Failed to write ACP history tmp");
+                return;
+            }
+            if let Err(e) = fs::rename(&tmp, &path) {
+                tracing::warn!(error = %e, "Failed to rename ACP history tmp");
+            }
+        }
+        Err(e) => tracing::warn!(error = %e, "Failed to serialize ACP history"),
+    }
+}
+
+pub fn load_acp_history() -> Option<AcpHistory> {
+    let path = acp_history_path();
+    let raw = fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn acp_history_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp")))
+        .join("octoweb")
+        .join("acp_history.json")
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Config {
     /// URL to load on startup
@@ -244,6 +317,10 @@ pub struct Config {
     /// Max prompt history entries to keep for AI sidebar assistant
     #[serde(default = "default_max_ai_prompt_history")]
     pub max_ai_prompt_history: usize,
+    /// Max persisted messages to keep per ACP chat session — older messages
+    /// are dropped from disk (FIFO) once a session exceeds this cap.
+    #[serde(default = "default_max_acp_session_messages")]
+    pub max_acp_session_messages: usize,
     /// Enable proactive background learning from browsing history
     #[serde(default = "default_true")]
     pub proactive_learning: bool,
@@ -258,6 +335,10 @@ fn default_max_prompt_history() -> usize {
 
 fn default_max_ai_prompt_history() -> usize {
     50
+}
+
+fn default_max_acp_session_messages() -> usize {
+    500
 }
 
 fn default_true() -> bool {
@@ -279,6 +360,7 @@ impl Default for Config {
             ai_edit_auto_hide: false,
             max_prompt_history: 50,
             max_ai_prompt_history: 50,
+            max_acp_session_messages: 500,
             proactive_learning: true,
             learning_interval_min: 30,
         }

--- a/src/inline_edit_html.rs
+++ b/src/inline_edit_html.rs
@@ -238,6 +238,13 @@ pub fn html() -> String {
     if (e.key === 'Escape') {
       e.preventDefault();
       ipc({ type: 'inline_edit_close' });
+    } else if (e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && (e.key === 'j' || e.key === 'J' || e.code === 'KeyJ')) {
+      // Ctrl+J → newline (mirrors Shift+Enter via the same WKWebView path)
+      e.preventDefault();
+      document.execCommand('insertText', false, '\n');
+      // Trailing "\n" doesn't expand scrollHeight, so caret can fall off the
+      // clipped textarea — keep it visible the same way Shift+Enter does.
+      input.scrollTop = input.scrollHeight;
     } else if (e.key === 'Enter' && !e.shiftKey && input.value.trim()) {
       e.preventDefault();
       ipc({ type: 'inline_edit_submit', prompt: input.value.trim() });

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -141,39 +141,64 @@ pub fn set_app_icon() {
     }
 }
 
-/// Install an observer for `NSApplicationDidResignActiveNotification` that
-/// resigns key window status from `chrome_ns_window` when our app deactivates.
+/// Install symmetric observers for `NSApplicationDidResignActiveNotification`
+/// and `NSApplicationDidBecomeActiveNotification` so that `chrome_ns_window`
+/// (our borderless transparent sidebar window) plays nicely with app
+/// activation transitions.
 ///
-/// Why this is needed: `chrome_win` is a borderless transparent child window.
-/// We explicitly call `makeKeyWindow` on it to route input into the sidebar
-/// WebView. macOS does NOT reliably auto-resign key from borderless child
-/// windows when the app deactivates (Cmd+Tab, click on another app's window),
-/// so the chrome window can stay key — meaning typing in the other app
-/// (e.g. pressing Enter in Slack) routes back to our WebView and pulls
-/// octoweb back to the front.
+/// **Resign on deactivate** — `chrome_win` is a borderless transparent child
+/// window. We explicitly call `makeKeyWindow` on it to route input into the
+/// sidebar WebView. macOS does NOT reliably auto-resign key from borderless
+/// child windows when the app deactivates (Cmd+Tab, click on another app's
+/// window), so the chrome window can stay key — meaning typing in the other
+/// app (e.g. pressing Enter in Slack) routes back to our WebView and pulls
+/// octoweb back to the front. On deactivation we explicitly call
+/// `[chrome_ns_window resignKeyWindow]` so AppKit hands key status to the
+/// actual frontmost app's window.
 ///
-/// Fix: on deactivation, explicitly call `[chrome_ns_window resignKeyWindow]`
-/// so AppKit hands key status to the actual frontmost app's window.
+/// **Restore on activate** — when our app reactivates after a *transient*
+/// deactivation (notification banner, Spotlight, brief Cmd-Tab) and the
+/// sidebar still owns input focus from the user's perspective
+/// (`sidebar_owns_key` is true), we re-promote `chrome_win` to key window
+/// and notify the event loop via `AppEvent::SidebarReFocus` so it can
+/// re-focus the sidebar WKWebView and the textarea inside it. Without this,
+/// the previous fix overshoots: any deactivation drops key permanently and
+/// the user's typing focus silently disappears.
 ///
-/// `chrome_ns_window` must be a non-null NSWindow pointer; the observer
-/// retains it for the app's lifetime (we never uninstall this observer).
+/// Both observers run on the main thread (queue: nil = posting thread; these
+/// notifications are posted on the main thread by NSApplication).
+///
+/// `chrome_ns_window` must be a non-null NSWindow pointer; observers retain
+/// it for the app's lifetime (we never uninstall them).
 ///
 /// # Safety
 /// Caller must pass a valid NSWindow pointer that lives for the duration of
 /// the app (chrome_win is never dropped).
-pub unsafe fn install_resign_key_on_deactivate(chrome_ns_window: *mut std::ffi::c_void) {
+pub unsafe fn install_app_active_observers(
+    chrome_ns_window: *mut std::ffi::c_void,
+    sidebar_owns_key: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    proxy: tao::event_loop::EventLoopProxy<crate::AppEvent>,
+) {
     use objc2::msg_send;
     use objc2::runtime::AnyObject;
     use objc2_foundation::NSString;
+    use std::sync::atomic::Ordering;
 
     if chrome_ns_window.is_null() {
         return;
     }
 
-    // Build the block: on notification, resignKeyWindow on chrome_ns_window.
+    let center: *mut AnyObject = msg_send![objc2::class!(NSNotificationCenter), defaultCenter];
+    if center.is_null() {
+        tracing::warn!("NSNotificationCenter defaultCenter is null");
+        return;
+    }
+
     // Capture the pointer as usize so the block is `Send + 'static` safe.
     let win_addr = chrome_ns_window as usize;
-    let block = block2::RcBlock::new(move |_notif: *mut AnyObject| {
+
+    // ── DidResignActive: drop key from chrome_win so it doesn't trap input ──
+    let resign_block = block2::RcBlock::new(move |_notif: *mut AnyObject| {
         let win = win_addr as *mut AnyObject;
         if win.is_null() {
             return;
@@ -184,25 +209,45 @@ pub unsafe fn install_resign_key_on_deactivate(chrome_ns_window: *mut std::ffi::
             tracing::debug!("chrome_win resigned key on app deactivate");
         }
     });
-
-    let center: *mut AnyObject = msg_send![objc2::class!(NSNotificationCenter), defaultCenter];
-    if center.is_null() {
-        tracing::warn!("NSNotificationCenter defaultCenter is null");
-        return;
-    }
-    let name = NSString::from_str("NSApplicationDidResignActiveNotification");
-    // addObserverForName:object:queue:usingBlock: returns an opaque token; we
-    // intentionally leak it (observer lives for app lifetime).
-    let _token: *mut AnyObject = msg_send![
+    let resign_name = NSString::from_str("NSApplicationDidResignActiveNotification");
+    let _resign_token: *mut AnyObject = msg_send![
         center,
-        addObserverForName: &*name,
+        addObserverForName: &*resign_name,
         object: std::ptr::null::<AnyObject>(),
         queue: std::ptr::null::<AnyObject>(),
-        usingBlock: &*block,
+        usingBlock: &*resign_block,
     ];
-    // Leak the block too — it must outlive the registration.
-    std::mem::forget(block);
-    tracing::debug!("installed NSApplicationDidResignActiveNotification observer");
+    std::mem::forget(resign_block);
+
+    // ── DidBecomeActive: if sidebar owned key before, restore it ───────────
+    let activate_block = block2::RcBlock::new(move |_notif: *mut AnyObject| {
+        if !sidebar_owns_key.load(Ordering::Relaxed) {
+            return;
+        }
+        let win = win_addr as *mut AnyObject;
+        if win.is_null() {
+            return;
+        }
+        let is_key: bool = unsafe { msg_send![win, isKeyWindow] };
+        if !is_key {
+            let _: () = unsafe { msg_send![win, makeKeyWindow] };
+            tracing::debug!("chrome_win re-promoted to key on app reactivate");
+        }
+        // Hand off to the event loop: wry WebView is !Send and must be
+        // touched on the main event-loop thread.
+        let _ = proxy.send_event(crate::AppEvent::SidebarReFocus);
+    });
+    let activate_name = NSString::from_str("NSApplicationDidBecomeActiveNotification");
+    let _activate_token: *mut AnyObject = msg_send![
+        center,
+        addObserverForName: &*activate_name,
+        object: std::ptr::null::<AnyObject>(),
+        queue: std::ptr::null::<AnyObject>(),
+        usingBlock: &*activate_block,
+    ];
+    std::mem::forget(activate_block);
+
+    tracing::debug!("installed NSApplication active/resign observers");
 }
 
 /// Push tab_id to front of MRU list, removing any prior occurrence.

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -141,6 +141,70 @@ pub fn set_app_icon() {
     }
 }
 
+/// Install an observer for `NSApplicationDidResignActiveNotification` that
+/// resigns key window status from `chrome_ns_window` when our app deactivates.
+///
+/// Why this is needed: `chrome_win` is a borderless transparent child window.
+/// We explicitly call `makeKeyWindow` on it to route input into the sidebar
+/// WebView. macOS does NOT reliably auto-resign key from borderless child
+/// windows when the app deactivates (Cmd+Tab, click on another app's window),
+/// so the chrome window can stay key — meaning typing in the other app
+/// (e.g. pressing Enter in Slack) routes back to our WebView and pulls
+/// octoweb back to the front.
+///
+/// Fix: on deactivation, explicitly call `[chrome_ns_window resignKeyWindow]`
+/// so AppKit hands key status to the actual frontmost app's window.
+///
+/// `chrome_ns_window` must be a non-null NSWindow pointer; the observer
+/// retains it for the app's lifetime (we never uninstall this observer).
+///
+/// # Safety
+/// Caller must pass a valid NSWindow pointer that lives for the duration of
+/// the app (chrome_win is never dropped).
+pub unsafe fn install_resign_key_on_deactivate(chrome_ns_window: *mut std::ffi::c_void) {
+    use objc2::msg_send;
+    use objc2::runtime::AnyObject;
+    use objc2_foundation::NSString;
+
+    if chrome_ns_window.is_null() {
+        return;
+    }
+
+    // Build the block: on notification, resignKeyWindow on chrome_ns_window.
+    // Capture the pointer as usize so the block is `Send + 'static` safe.
+    let win_addr = chrome_ns_window as usize;
+    let block = block2::RcBlock::new(move |_notif: *mut AnyObject| {
+        let win = win_addr as *mut AnyObject;
+        if win.is_null() {
+            return;
+        }
+        let is_key: bool = unsafe { msg_send![win, isKeyWindow] };
+        if is_key {
+            let _: () = unsafe { msg_send![win, resignKeyWindow] };
+            tracing::debug!("chrome_win resigned key on app deactivate");
+        }
+    });
+
+    let center: *mut AnyObject = msg_send![objc2::class!(NSNotificationCenter), defaultCenter];
+    if center.is_null() {
+        tracing::warn!("NSNotificationCenter defaultCenter is null");
+        return;
+    }
+    let name = NSString::from_str("NSApplicationDidResignActiveNotification");
+    // addObserverForName:object:queue:usingBlock: returns an opaque token; we
+    // intentionally leak it (observer lives for app lifetime).
+    let _token: *mut AnyObject = msg_send![
+        center,
+        addObserverForName: &*name,
+        object: std::ptr::null::<AnyObject>(),
+        queue: std::ptr::null::<AnyObject>(),
+        usingBlock: &*block,
+    ];
+    // Leak the block too — it must outlive the registration.
+    std::mem::forget(block);
+    tracing::debug!("installed NSApplicationDidResignActiveNotification observer");
+}
+
 /// Push tab_id to front of MRU list, removing any prior occurrence.
 /// Keeps the list bounded to 64 entries (more than enough for any session).
 pub fn mru_push(mru: &mut Vec<usize>, id: usize) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5343,6 +5343,7 @@ fn persist_acp_history(sessions: &[AcpSession], active_id: u64, max_msgs: usize)
 }
 
 /// Save session state and exit the event loop.
+#[allow(clippy::too_many_arguments)]
 fn save_and_exit(
     tabs: &Arc<Mutex<browser::TabManager>>,
     favicon_cache: &std::collections::HashMap<String, String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,7 @@ enum AppEvent {
     AcpSessionSwitch(u64),    // (session_id) — switch active session
     AcpSessionRename(u64, String), // (session_id, title) — rename session
     SidebarReady,             // sidebar JS finished initializing — push restore
+    SidebarReFocus,           // app reactivated while sidebar owned key — restore textarea focus
     AskAI(String),            // overlay ⌘⇧Enter — open sidebar + send prompt
     ToggleDevTools,           // Cmd+Shift+I — open devtools for active tab
     OpenInNewTab(String),     // Cmd+click / target=_blank — open URL in new tab and switch to it
@@ -232,6 +233,11 @@ fn main() {
     let find_bar_hotkey_visible = Arc::new(AtomicBool::new(false));
     let inline_edit_hotkey_visible = Arc::new(AtomicBool::new(false));
     let sidebar_hotkey_visible = Arc::new(AtomicBool::new(false));
+    // Tracks whether chrome_win (sidebar host) currently owns logical input
+    // focus. Read by the NSApplicationDidBecomeActive observer to decide
+    // whether to restore key status + textarea focus after a transient
+    // deactivation (notification banner, Spotlight, brief Cmd-Tab).
+    let sidebar_owns_key = Arc::new(AtomicBool::new(false));
     // Note: app-frontmost state is queried on demand via `is_app_active()`
     // (NSApplication.isActive). We deliberately do NOT cache via
     // WindowEvent::Focused — modal panels from other apps (1Password ⌘\,
@@ -316,12 +322,16 @@ fn main() {
     let chrome_win = Arc::new(chrome_win);
     let chrome_win_id = chrome_win.id();
 
-    // Resign chrome_win's key status whenever the app deactivates. Without this,
-    // borderless child windows can hold key status across Cmd+Tab / app switch,
-    // routing keys (e.g. Enter pressed in Slack) back to our sidebar WebView
-    // and pulling octoweb back to the front.
+    // Resign chrome_win's key status on deactivate (so Slack-Enter doesn't
+    // route back to us) and restore it on reactivate when the sidebar still
+    // owned focus (so transient deactivations — banners, Spotlight — don't
+    // silently steal the user's typing focus).
     unsafe {
-        macos::install_resign_key_on_deactivate(chrome_win.ns_window());
+        macos::install_app_active_observers(
+            chrome_win.ns_window(),
+            Arc::clone(&sidebar_owns_key),
+            proxy.clone(),
+        );
     }
 
     // ── Browser WebView factory ───────────────────────────────────────────
@@ -3509,6 +3519,7 @@ fn main() {
                     let _ = sidebar_wv.set_visible(false);
                     sidebar_visible = false;
                     sidebar_hotkey_visible.store(false, Ordering::Relaxed);
+                    sidebar_owns_key.store(false, Ordering::Relaxed);
                     // Return key window status to browser_win so the page
                     // WebView receives keyboard input again.
                     browser_win.set_focus();
@@ -3524,6 +3535,7 @@ fn main() {
                     let _ = sidebar_wv.set_visible(true);
                     sidebar_visible = true;
                     sidebar_hotkey_visible.store(true, Ordering::Relaxed);
+                    sidebar_owns_key.store(true, Ordering::Relaxed);
                     // Seed sidebar with persisted AI prompt history so older prompts
                     // are reachable via Ctrl+P / Ctrl+N inside any session.
                     let hist_json = serde_json::to_string(&ai_prompt_history)
@@ -3901,6 +3913,21 @@ fn main() {
                 let _ = sidebar_wv.evaluate_script(&format!(
                     "window.__switchSession && window.__switchSession({active})"
                 ));
+            }
+
+            // ── Sidebar re-focus after transient app reactivation ─────────
+            // Posted by the NSApplicationDidBecomeActive observer (macos.rs)
+            // when our app reactivates and the sidebar still owns logical
+            // focus. Re-promotes the WKWebView and the textarea so the user's
+            // typing focus survives notification banners, Spotlight, etc.
+            Event::UserEvent(AppEvent::SidebarReFocus) if sidebar_visible => {
+                let _ = sidebar_wv.focus();
+                let _ = sidebar_wv.evaluate_script(
+                    "(function(){var el=document.getElementById('prompt-input');\
+                     if(!el)return;if(document.activeElement===el)return;\
+                     var n=0;(function f(){if(n++>20)return;el.focus();\
+                     if(document.activeElement===el)return;setTimeout(f,30)})()})()"
+                );
             }
 
             // ── Ask AI: open sidebar + inject prompt ──────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -1353,9 +1353,17 @@ fn main() {
         Some(h) if !h.sessions.is_empty() => {
             let mut sessions: Vec<AcpSession> = Vec::with_capacity(h.sessions.len());
             let mut max_id: u64 = 0;
-            for snap in h.sessions.into_iter() {
+            let cap = cfg.max_acp_session_messages;
+            for mut snap in h.sessions.into_iter() {
                 if snap.id > max_id {
                     max_id = snap.id;
+                }
+                // Defensive cap on load — if the file was hand-edited or the
+                // cap was lowered between runs, we don't want to bring oversized
+                // history back into memory. FIFO drop matches push_acp_msg.
+                if snap.messages.len() > cap {
+                    let drop = snap.messages.len() - cap;
+                    snap.messages.drain(..drop);
                 }
                 let cmd = match &snap.acp_session_id {
                     Some(id) => format!("octomind acp {} --resume {}", snap.tag, id),
@@ -2179,7 +2187,7 @@ fn main() {
                             // on each turn and don't survive replay anyway.
                             if !s.agent_buf.is_empty() {
                                 let buf = std::mem::take(&mut s.agent_buf);
-                                push_acp_msg(s, "agent", buf);
+                                push_acp_msg(s, "agent", buf, cfg.max_acp_session_messages);
                                 should_persist = true;
                             }
                         }
@@ -2203,7 +2211,7 @@ fn main() {
                             // the user sees the same thing they had on screen.
                             if !s.agent_buf.is_empty() {
                                 let buf = std::mem::take(&mut s.agent_buf);
-                                push_acp_msg(s, "agent", buf);
+                                push_acp_msg(s, "agent", buf, cfg.max_acp_session_messages);
                                 should_persist = true;
                             }
                         }
@@ -2232,7 +2240,7 @@ fn main() {
                             // mirrors what the user saw before the disconnect.
                             if !s.agent_buf.is_empty() {
                                 let buf = std::mem::take(&mut s.agent_buf);
-                                push_acp_msg(s, "agent", buf);
+                                push_acp_msg(s, "agent", buf, cfg.max_acp_session_messages);
                                 should_persist = true;
                             }
                             if s.retry_count < ACP_MAX_RETRIES {
@@ -2242,7 +2250,7 @@ fn main() {
                                 // rows into the message history. Subsequent retries don't spam.
                                 if s.retry_count == 0 {
                                     let m = format!("agent disconnected: {err} — reconnecting");
-                                    push_acp_msg(s, "error", m.clone());
+                                    push_acp_msg(s, "error", m.clone(), cfg.max_acp_session_messages);
                                     should_persist = true;
                                     user_facing_err = Some(m);
                                 }
@@ -2257,7 +2265,7 @@ fn main() {
                                 decision = Some(Decision::Reconnect(s.reconnect_gen, delay));
                             } else {
                                 tracing::error!(session_id = sid, "ACP max reconnection retries exceeded");
-                                push_acp_msg(s, "error", err.clone());
+                                push_acp_msg(s, "error", err.clone(), cfg.max_acp_session_messages);
                                 should_persist = true;
                                 user_facing_err = Some(err.clone());
                                 decision = Some(Decision::MaxExceeded);
@@ -3589,7 +3597,7 @@ fn main() {
                 let mut should_persist = false;
                 if let Some(s) = sessions.iter_mut().find(|s| s.id == sid) {
                     if !text.is_empty() {
-                        push_acp_msg(s, "user", text.clone());
+                        push_acp_msg(s, "user", text.clone(), cfg.max_acp_session_messages);
                         should_persist = true;
                     }
                     if let Some(ref handle) = s.handle {
@@ -3642,9 +3650,9 @@ fn main() {
                         // synthetic error so a restart shows the same trail.
                         if !s.agent_buf.is_empty() {
                             let buf = std::mem::take(&mut s.agent_buf);
-                            push_acp_msg(s, "agent", buf);
+                            push_acp_msg(s, "agent", buf, cfg.max_acp_session_messages);
                         }
-                        push_acp_msg(s, "error", "agent force-stopped and reconnected".to_string());
+                        push_acp_msg(s, "error", "agent force-stopped and reconnected".to_string(), cfg.max_acp_session_messages);
                         should_persist = true;
                         let _ = sidebar_wv.evaluate_script(&format!(
                             "window.__setThinking && window.__setThinking({sid},false)"
@@ -5281,9 +5289,19 @@ fn build_learning_prompt(
 }
 
 /// Append a message to a session's persisted log, stamping it with the
-/// current wall-clock time. Cheap — caller is expected to call
-/// `persist_acp_history` afterwards (debounced via thread spawn).
-fn push_acp_msg(s: &mut AcpSession, role: &str, text: String) {
+/// current wall-clock time, and FIFO-drop the oldest once over the cap.
+/// Capping in memory (not just on disk) is what bounds long-running
+/// session growth — without it the in-memory `Vec<AcpMessage>` grows
+/// forever even though the on-disk snapshot stays bounded.
+///
+/// We do NOT rely on the agent subprocess to police context size:
+/// `octomind`'s own conversation `Vec<Message>` is unbounded, and it only
+/// compresses on explicit `/done` / `/truncate` slash commands — so the
+/// truncation responsibility lives here on the client side.
+///
+/// Caller is expected to dispatch `persist_acp_history` afterwards
+/// (fire-and-forget on a worker thread).
+fn push_acp_msg(s: &mut AcpSession, role: &str, text: String, max_msgs: usize) {
     let ts = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
@@ -5293,6 +5311,10 @@ fn push_acp_msg(s: &mut AcpSession, role: &str, text: String) {
         text,
         ts,
     });
+    if s.messages.len() > max_msgs {
+        let drop = s.messages.len() - max_msgs;
+        s.messages.drain(..drop);
+    }
 }
 
 /// Snapshot every ACP session into `AcpHistory` and dispatch the JSON write

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,7 @@ enum AppEvent {
     AcpSessionCloseActive,    // ⌘W in sidebar — close currently active session
     AcpSessionSwitch(u64),    // (session_id) — switch active session
     AcpSessionRename(u64, String), // (session_id, title) — rename session
+    SidebarReady,             // sidebar JS finished initializing — push restore
     AskAI(String),            // overlay ⌘⇧Enter — open sidebar + send prompt
     ToggleDevTools,           // Cmd+Shift+I — open devtools for active tab
     OpenInNewTab(String),     // Cmd+click / target=_blank — open URL in new tab and switch to it
@@ -154,6 +155,19 @@ struct AcpSession {
     /// the agent restores its in-memory conversation context. Cleared on
     /// AcpSetAgent / AcpClearSession (which want a fresh chat).
     acp_session_id: Option<String>,
+    /// Persisted message log — user prompts, finalized agent responses,
+    /// errors. Survives app restarts via `acp_history.json`. Excludes tool
+    /// runs and inline images (live-only). Capped at `max_acp_session_messages`.
+    messages: Vec<config::AcpMessage>,
+    /// Accumulator for the in-flight agent response. Filled on every
+    /// `AgentEvent::Chunk` and flushed into `messages` on Done / Cancelled /
+    /// Error so the persisted log only contains finalized turns.
+    agent_buf: String,
+    /// Cached `AvailableCommands` payload (already JSON-serialized for direct
+    /// re-injection into JS). Set when the agent emits commands; re-pushed on
+    /// `sidebar_ready` so slash-command auto-complete survives sidebar opens
+    /// that occur after the agent already announced its commands.
+    available_commands_json: Option<String>,
 }
 
 /// Hard cap on parallel ACP sessions — each is a forked subprocess with its own
@@ -936,6 +950,9 @@ fn main() {
                             let title = v["title"].as_str().unwrap_or("").to_string();
                             let _ = p.send_event(AppEvent::AcpSessionRename(sid, title));
                         }
+                        Some("sidebar_ready") => {
+                            let _ = p.send_event(AppEvent::SidebarReady);
+                        }
                         Some("copy_text") => {
                             if let Some(text) = v["text"].as_str() {
                                 unsafe {
@@ -1326,24 +1343,67 @@ fn main() {
             let _ = proxy.send_event(AppEvent::AcpWake);
         }
     };
-    let mut next_session_id: u64 = 1;
-    let default_session = AcpSession {
-        id: next_session_id,
-        title: "Assistant".to_string(),
-        tag: "octoweb:assistant".to_string(),
-        handle: acp::AcpHandle::connect(
-            "octomind acp octoweb:assistant",
-            make_wake(acp_proxy.clone()),
-        )
-        .ok(),
-        retry_count: 0,
-        reconnect_gen: 0,
-        last_cancel_at: None,
-        acp_session_id: None,
+    // Restore persisted ACP history (sessions + per-session message log) if
+    // present, else start with a fresh default Assistant session. `--resume`
+    // is passed when an `acp_session_id` was captured before — the agent then
+    // restores its in-memory conversation context, matching what the user
+    // sees in the replayed message log.
+    let persisted_acp = config::load_acp_history();
+    let (mut sessions, mut next_session_id, mut active_session_id) = match persisted_acp {
+        Some(h) if !h.sessions.is_empty() => {
+            let mut sessions: Vec<AcpSession> = Vec::with_capacity(h.sessions.len());
+            let mut max_id: u64 = 0;
+            for snap in h.sessions.into_iter() {
+                if snap.id > max_id {
+                    max_id = snap.id;
+                }
+                let cmd = match &snap.acp_session_id {
+                    Some(id) => format!("octomind acp {} --resume {}", snap.tag, id),
+                    None => format!("octomind acp {}", snap.tag),
+                };
+                let handle = acp::AcpHandle::connect(&cmd, make_wake(acp_proxy.clone())).ok();
+                sessions.push(AcpSession {
+                    id: snap.id,
+                    title: snap.title,
+                    tag: snap.tag,
+                    handle,
+                    retry_count: 0,
+                    reconnect_gen: 0,
+                    last_cancel_at: None,
+                    acp_session_id: snap.acp_session_id,
+                    messages: snap.messages,
+                    agent_buf: String::new(),
+                    available_commands_json: None,
+                });
+            }
+            let active = if sessions.iter().any(|s| s.id == h.active_id) {
+                h.active_id
+            } else {
+                sessions[0].id
+            };
+            (sessions, max_id + 1, active)
+        }
+        _ => {
+            let default_session = AcpSession {
+                id: 1,
+                title: "Assistant".to_string(),
+                tag: "octoweb:assistant".to_string(),
+                handle: acp::AcpHandle::connect(
+                    "octomind acp octoweb:assistant",
+                    make_wake(acp_proxy.clone()),
+                )
+                .ok(),
+                retry_count: 0,
+                reconnect_gen: 0,
+                last_cancel_at: None,
+                acp_session_id: None,
+                messages: Vec::new(),
+                agent_buf: String::new(),
+                available_commands_json: None,
+            };
+            (vec![default_session], 2u64, 1u64)
+        }
     };
-    let mut active_session_id: u64 = next_session_id;
-    next_session_id += 1;
-    let mut sessions: Vec<AcpSession> = vec![default_session];
 
     // ACP reconnection backoff bounds (shared across all sessions — backoff state
     // itself lives per-session in `AcpSession::retry_count` / `reconnect_gen`).
@@ -2018,13 +2078,23 @@ fn main() {
             for ev in events {
                 match ev {
                     acp::AgentEvent::Connected(acp_sid) => {
+                        let mut should_persist = false;
                         if let Some(s) = sessions.iter_mut().find(|s| s.id == sid) {
                             s.retry_count = 0;
-                            s.acp_session_id = Some(acp_sid);
+                            // Persist the new acp_session_id so a future cold-
+                            // start can pass `--resume <id>` and recover the
+                            // agent's own conversation context.
+                            if s.acp_session_id.as_deref() != Some(&acp_sid) {
+                                s.acp_session_id = Some(acp_sid);
+                                should_persist = true;
+                            }
                         }
                         let _ = sidebar_wv.evaluate_script(&format!(
                             "window.__setSessionStatus && window.__setSessionStatus({sid},'ready')"
                         ));
+                        if should_persist {
+                            persist_acp_history(&sessions, active_session_id, cfg.max_acp_session_messages);
+                        }
                     }
                     acp::AgentEvent::Image { data, mime_type } => {
                         let _ = sidebar_wv.evaluate_script(&format!(
@@ -2032,6 +2102,12 @@ fn main() {
                         ));
                     }
                     acp::AgentEvent::Chunk(chunk) => {
+                        // Accumulate the in-flight agent response so we can
+                        // commit one finalized "agent" message to the persisted
+                        // log on Done/Cancelled — no save during streaming.
+                        if let Some(s) = sessions.iter_mut().find(|s| s.id == sid) {
+                            s.agent_buf.push_str(&chunk);
+                        }
                         let escaped = webview_utils::escape_js_template(&chunk);
                         let _ = sidebar_wv.evaluate_script(&format!(
                             "window.__appendChunk && window.__appendChunk({sid},`{escaped}`)"
@@ -2082,14 +2158,30 @@ fn main() {
                             serde_json::json!({"name": c.name, "description": c.description, "hint": c.hint})
                         }).collect();
                         let json_str = serde_json::to_string(&json).unwrap_or_else(|_| "[]".into());
+                        // Cache so we can re-push to JS on `sidebar_ready` —
+                        // the agent only emits commands once on connect, but
+                        // the sidebar may not be open yet at that moment.
+                        if let Some(s) = sessions.iter_mut().find(|s| s.id == sid) {
+                            s.available_commands_json = Some(json_str.clone());
+                        }
                         let escaped = webview_utils::escape_js_template(&json_str);
                         let _ = sidebar_wv.evaluate_script(&format!(
                             "window.__setAvailableCommands && window.__setAvailableCommands({sid},`{escaped}`)"
                         ));
                     }
                     acp::AgentEvent::Done => {
+                        let mut should_persist = false;
                         if let Some(s) = sessions.iter_mut().find(|s| s.id == sid) {
                             s.last_cancel_at = None;
+                            // Flush the streamed response into the persisted
+                            // log as a single "agent" message. Tool runs and
+                            // images stay live-only — they're rebuilt fresh
+                            // on each turn and don't survive replay anyway.
+                            if !s.agent_buf.is_empty() {
+                                let buf = std::mem::take(&mut s.agent_buf);
+                                push_acp_msg(s, "agent", buf);
+                                should_persist = true;
+                            }
                         }
                         let _ = sidebar_wv.evaluate_script(&format!(
                             "window.__setThinking && window.__setThinking({sid},false)"
@@ -2099,73 +2191,122 @@ fn main() {
                                 "window.__setBadge && window.__setBadge(true)"
                             );
                         }
+                        if should_persist {
+                            persist_acp_history(&sessions, active_session_id, cfg.max_acp_session_messages);
+                        }
                     }
                     acp::AgentEvent::Cancelled => {
+                        let mut should_persist = false;
                         if let Some(s) = sessions.iter_mut().find(|s| s.id == sid) {
                             s.last_cancel_at = None;
+                            // Save partial response (cancelled mid-stream) so
+                            // the user sees the same thing they had on screen.
+                            if !s.agent_buf.is_empty() {
+                                let buf = std::mem::take(&mut s.agent_buf);
+                                push_acp_msg(s, "agent", buf);
+                                should_persist = true;
+                            }
                         }
                         let _ = sidebar_wv.evaluate_script(&format!(
                             "window.__setThinking && window.__setThinking({sid},false)"
                         ));
+                        if should_persist {
+                            persist_acp_history(&sessions, active_session_id, cfg.max_acp_session_messages);
+                        }
                     }
                     acp::AgentEvent::Error(err) => {
                         tracing::warn!(session_id = sid, error = %err, "ACP connection error");
-                        // Find the session and schedule per-session reconnection.
-                        let Some(s) = sessions.iter_mut().find(|s| s.id == sid) else { continue };
-                        // Drop dead handle immediately so prompts aren't silently lost.
-                        s.handle = None;
-                        s.last_cancel_at = None;
-                        if s.retry_count < ACP_MAX_RETRIES {
-                            // First disconnect of this cycle: surface to chat so the user
-                            // knows their in-flight prompt is gone (it isn't replayed) and
-                            // so __appendError → __setThinking(false) flushes pending tool
-                            // rows into the message history. Subsequent retries don't spam.
-                            if s.retry_count == 0 {
-                                let escaped = webview_utils::escape_js_template(&format!(
-                                    "agent disconnected: {err} — reconnecting"
-                                ));
-                                let _ = sidebar_wv.evaluate_script(&format!(
-                                    "window.__appendError && window.__appendError({sid},`{escaped}`)"
-                                ));
+                        // Mutate session state in an inner scope so the &mut borrow
+                        // is released before we call evaluate_script + persist (both
+                        // read &sessions). Decision drives the post-borrow JS calls.
+                        enum Decision { Reconnect(u64, u64), MaxExceeded }
+                        let decision: Option<Decision>;
+                        let mut should_persist = false;
+                        let mut user_facing_err: Option<String> = None;
+                        {
+                            let Some(s) = sessions.iter_mut().find(|s| s.id == sid) else { continue };
+                            // Drop dead handle immediately so prompts aren't silently lost.
+                            s.handle = None;
+                            s.last_cancel_at = None;
+                            // Save partial in-flight response so the persisted log
+                            // mirrors what the user saw before the disconnect.
+                            if !s.agent_buf.is_empty() {
+                                let buf = std::mem::take(&mut s.agent_buf);
+                                push_acp_msg(s, "agent", buf);
+                                should_persist = true;
                             }
-                            s.retry_count += 1;
-                            let delay = std::cmp::min(
-                                ACP_BASE_DELAY_SECS * 2u64.pow(s.retry_count - 1),
-                                ACP_MAX_DELAY_SECS,
-                            );
-                            tracing::info!(session_id = sid, retry = s.retry_count, delay_s = delay, "scheduling ACP reconnection");
-                            let _ = sidebar_wv.evaluate_script(&format!(
-                                "window.__setSessionStatus && window.__setSessionStatus({sid},'connecting')"
-                            ));
-                            // Bump generation so any previously scheduled timer for this session is ignored.
-                            s.reconnect_gen += 1;
-                            let gen = s.reconnect_gen;
-                            let proxy_clone = acp_proxy.clone();
-                            std::thread::spawn(move || {
-                                std::thread::sleep(std::time::Duration::from_secs(delay));
-                                let _ = proxy_clone.send_event(AppEvent::AcpReconnect(sid, gen));
-                            });
-                        } else {
-                            tracing::error!(session_id = sid, "ACP max reconnection retries exceeded");
-                            let _ = sidebar_wv.evaluate_script(&format!(
-                                "window.__setSessionStatus && window.__setSessionStatus({sid},'error')"
-                            ));
-                            let escaped = webview_utils::escape_js_template(&err);
-                            let _ = sidebar_wv.evaluate_script(&format!(
-                                "window.__appendError && window.__appendError({sid},`{escaped}`)"
-                            ));
-                            if !sidebar_visible {
-                                let _ = address_bar_wv.evaluate_script(
-                                    "window.__setBadge && window.__setBadge(true)"
-                                );
-                                if !notification_visible {
-                                    let _ = notification_wv.set_visible(true);
-                                    notification_visible = true;
+                            if s.retry_count < ACP_MAX_RETRIES {
+                                // First disconnect of this cycle: surface to chat so the user
+                                // knows their in-flight prompt is gone (it isn't replayed) and
+                                // so __appendError → __setThinking(false) flushes pending tool
+                                // rows into the message history. Subsequent retries don't spam.
+                                if s.retry_count == 0 {
+                                    let m = format!("agent disconnected: {err} — reconnecting");
+                                    push_acp_msg(s, "error", m.clone());
+                                    should_persist = true;
+                                    user_facing_err = Some(m);
                                 }
-                                let _ = notification_wv.evaluate_script(&format!(
-                                    "window.__show && window.__show(`{escaped}`)"
-                                ));
+                                s.retry_count += 1;
+                                let delay = std::cmp::min(
+                                    ACP_BASE_DELAY_SECS * 2u64.pow(s.retry_count - 1),
+                                    ACP_MAX_DELAY_SECS,
+                                );
+                                tracing::info!(session_id = sid, retry = s.retry_count, delay_s = delay, "scheduling ACP reconnection");
+                                // Bump generation so any previously scheduled timer for this session is ignored.
+                                s.reconnect_gen += 1;
+                                decision = Some(Decision::Reconnect(s.reconnect_gen, delay));
+                            } else {
+                                tracing::error!(session_id = sid, "ACP max reconnection retries exceeded");
+                                push_acp_msg(s, "error", err.clone());
+                                should_persist = true;
+                                user_facing_err = Some(err.clone());
+                                decision = Some(Decision::MaxExceeded);
                             }
+                        }
+                        match decision {
+                            Some(Decision::Reconnect(gen, delay)) => {
+                                if let Some(m) = &user_facing_err {
+                                    let escaped = webview_utils::escape_js_template(m);
+                                    let _ = sidebar_wv.evaluate_script(&format!(
+                                        "window.__appendError && window.__appendError({sid},`{escaped}`)"
+                                    ));
+                                }
+                                let _ = sidebar_wv.evaluate_script(&format!(
+                                    "window.__setSessionStatus && window.__setSessionStatus({sid},'connecting')"
+                                ));
+                                let proxy_clone = acp_proxy.clone();
+                                std::thread::spawn(move || {
+                                    std::thread::sleep(std::time::Duration::from_secs(delay));
+                                    let _ = proxy_clone.send_event(AppEvent::AcpReconnect(sid, gen));
+                                });
+                            }
+                            Some(Decision::MaxExceeded) => {
+                                let _ = sidebar_wv.evaluate_script(&format!(
+                                    "window.__setSessionStatus && window.__setSessionStatus({sid},'error')"
+                                ));
+                                if let Some(m) = &user_facing_err {
+                                    let escaped = webview_utils::escape_js_template(m);
+                                    let _ = sidebar_wv.evaluate_script(&format!(
+                                        "window.__appendError && window.__appendError({sid},`{escaped}`)"
+                                    ));
+                                    if !sidebar_visible {
+                                        let _ = address_bar_wv.evaluate_script(
+                                            "window.__setBadge && window.__setBadge(true)"
+                                        );
+                                        if !notification_visible {
+                                            let _ = notification_wv.set_visible(true);
+                                            notification_visible = true;
+                                        }
+                                        let _ = notification_wv.evaluate_script(&format!(
+                                            "window.__show && window.__show(`{escaped}`)"
+                                        ));
+                                    }
+                                }
+                            }
+                            None => {}
+                        }
+                        if should_persist {
+                            persist_acp_history(&sessions, active_session_id, cfg.max_acp_session_messages);
                         }
                     }
                 }
@@ -3445,7 +3586,12 @@ fn main() {
                     let snapshot = ai_prompt_history.clone();
                     std::thread::spawn(move || config::save_ai_prompt_history(&snapshot));
                 }
+                let mut should_persist = false;
                 if let Some(s) = sessions.iter_mut().find(|s| s.id == sid) {
+                    if !text.is_empty() {
+                        push_acp_msg(s, "user", text.clone());
+                        should_persist = true;
+                    }
                     if let Some(ref handle) = s.handle {
                         if !handle.send_prompt(text, images) {
                             // Channel dead — drop handle so reconnection can re-arm.
@@ -3456,6 +3602,9 @@ fn main() {
                         }
                     }
                 }
+                if should_persist {
+                    persist_acp_history(&sessions, active_session_id, cfg.max_acp_session_messages);
+                }
             }
 
             // ── ACP cancel (stop button) ───────────────────────────────────────────
@@ -3464,6 +3613,7 @@ fn main() {
             // handle with the same agent tag. This is the user's escape hatch when
             // the agent ignores `CancelNotification` (e.g. wedged on a syscall).
             Event::UserEvent(AppEvent::AcpCancel(sid)) => {
+                let mut should_persist = false;
                 if let Some(s) = sessions.iter_mut().find(|s| s.id == sid) {
                     let now = std::time::Instant::now();
                     let recent = s
@@ -3487,6 +3637,15 @@ fn main() {
                         )
                         .ok();
                         s.last_cancel_at = None;
+                        // Save partial agent text (the user just force-killed
+                        // mid-stream — keep what they already saw) and the
+                        // synthetic error so a restart shows the same trail.
+                        if !s.agent_buf.is_empty() {
+                            let buf = std::mem::take(&mut s.agent_buf);
+                            push_acp_msg(s, "agent", buf);
+                        }
+                        push_acp_msg(s, "error", "agent force-stopped and reconnected".to_string());
+                        should_persist = true;
                         let _ = sidebar_wv.evaluate_script(&format!(
                             "window.__setThinking && window.__setThinking({sid},false)"
                         ));
@@ -3501,10 +3660,14 @@ fn main() {
                         s.last_cancel_at = Some(now);
                     }
                 }
+                if should_persist {
+                    persist_acp_history(&sessions, active_session_id, cfg.max_acp_session_messages);
+                }
             }
 
             // ── ACP set agent for an existing session (kills + respawns its handle) ──
             Event::UserEvent(AppEvent::AcpSetAgent(sid, tag)) => {
+                let mut should_persist = false;
                 if let Some(s) = sessions.iter_mut().find(|s| s.id == sid) {
                     s.tag = tag.clone();
                     s.retry_count = 0;
@@ -3516,6 +3679,11 @@ fn main() {
                         make_wake(acp_proxy.clone()),
                     )
                     .ok();
+                    // Switching agents discards the prior conversation context.
+                    s.messages.clear();
+                    s.agent_buf.clear();
+                    s.available_commands_json = None;
+                    should_persist = true;
                     let _ = sidebar_wv.evaluate_script(&format!(
                         "window.__setSessionStatus && window.__setSessionStatus({sid},'connecting')"
                     ));
@@ -3524,10 +3692,14 @@ fn main() {
                         "window.__updateSessionTag && window.__updateSessionTag({sid},`{escaped}`)"
                     ));
                 }
+                if should_persist {
+                    persist_acp_history(&sessions, active_session_id, cfg.max_acp_session_messages);
+                }
             }
 
             // ── ACP clear session (same agent, fresh chat) ────────────────────────
             Event::UserEvent(AppEvent::AcpClearSession(sid)) => {
+                let mut should_persist = false;
                 if let Some(s) = sessions.iter_mut().find(|s| s.id == sid) {
                     s.retry_count = 0;
                     s.reconnect_gen += 1;
@@ -3538,9 +3710,16 @@ fn main() {
                         make_wake(acp_proxy.clone()),
                     )
                     .ok();
+                    // User asked for a fresh chat — drop the persisted log too.
+                    s.messages.clear();
+                    s.agent_buf.clear();
+                    should_persist = true;
                     let _ = sidebar_wv.evaluate_script(&format!(
                         "window.__setSessionStatus && window.__setSessionStatus({sid},'connecting')"
                     ));
+                }
+                if should_persist {
+                    persist_acp_history(&sessions, active_session_id, cfg.max_acp_session_messages);
                 }
             }
 
@@ -3572,6 +3751,9 @@ fn main() {
                         reconnect_gen: 0,
                         last_cancel_at: None,
                         acp_session_id: None,
+                        messages: Vec::new(),
+                        agent_buf: String::new(),
+                        available_commands_json: None,
                     });
                     active_session_id = sid; // auto-switch to new session
                     let etitle = webview_utils::escape_js_template(&title);
@@ -3582,6 +3764,7 @@ fn main() {
                     let _ = sidebar_wv.evaluate_script(&format!(
                         "window.__switchSession && window.__switchSession({sid})"
                     ));
+                    persist_acp_history(&sessions, active_session_id, cfg.max_acp_session_messages);
                 }
             }
 
@@ -3608,6 +3791,7 @@ fn main() {
                     let _ = sidebar_wv.evaluate_script(&format!(
                         "window.__removeSession && window.__removeSession({sid})"
                     ));
+                    persist_acp_history(&sessions, active_session_id, cfg.max_acp_session_messages);
                 }
             }
 
@@ -3619,17 +3803,88 @@ fn main() {
                 let _ = sidebar_wv.evaluate_script(&format!(
                     "window.__switchSession && window.__switchSession({sid})"
                 ));
+                persist_acp_history(&sessions, active_session_id, cfg.max_acp_session_messages);
             }
 
             // ── ACP rename session (title only) ────────────────────────────────────
             Event::UserEvent(AppEvent::AcpSessionRename(sid, title)) => {
+                let mut should_persist = false;
                 if let Some(s) = sessions.iter_mut().find(|s| s.id == sid) {
                     s.title = title.clone();
+                    should_persist = true;
                     let etitle = webview_utils::escape_js_template(&title);
                     let _ = sidebar_wv.evaluate_script(&format!(
                         "window.__renameSession && window.__renameSession({sid},`{etitle}`)"
                     ));
                 }
+                if should_persist {
+                    persist_acp_history(&sessions, active_session_id, cfg.max_acp_session_messages);
+                }
+            }
+
+            // ── Sidebar JS finished init — push persisted state to JS ──────────────
+            // The JS initDefault always creates sid=1 as a placeholder. Here we
+            // reconcile JS state with Rust state: rename/retag sid=1 if needed,
+            // add any extra persisted sessions, replay messages, restore the
+            // last-active session, and re-broadcast cached available_commands.
+            Event::UserEvent(AppEvent::SidebarReady) => {
+                let rust_has_sid1 = sessions.iter().any(|s| s.id == 1);
+                for s in sessions.iter() {
+                    let sid = s.id;
+                    let etitle = webview_utils::escape_js_template(&s.title);
+                    let etag = webview_utils::escape_js_template(&s.tag);
+                    // Status mirrors the live handle state: ready iff connected,
+                    // else connecting (reconnect loop will resolve to error if needed).
+                    let status = if s.handle.is_some() && s.acp_session_id.is_some() {
+                        "ready"
+                    } else if s.handle.is_some() {
+                        "connecting"
+                    } else {
+                        "error"
+                    };
+                    // No-op if the session is already in the JS map (e.g. sid=1
+                    // from initDefault). Title/tag/status are pushed below.
+                    let _ = sidebar_wv.evaluate_script(&format!(
+                        "window.__addSession && window.__addSession({sid},`{etitle}`,`{etag}`,'{status}')"
+                    ));
+                    // Override the JS placeholder values for sid=1 (it was added
+                    // before we knew the persisted title/tag).
+                    if sid == 1 {
+                        let _ = sidebar_wv.evaluate_script(&format!(
+                            "window.__renameSession && window.__renameSession({sid},`{etitle}`)"
+                        ));
+                        let _ = sidebar_wv.evaluate_script(&format!(
+                            "window.__updateSessionTag && window.__updateSessionTag({sid},`{etag}`)"
+                        ));
+                        let _ = sidebar_wv.evaluate_script(&format!(
+                            "window.__setSessionStatus && window.__setSessionStatus({sid},'{status}')"
+                        ));
+                    }
+                    if let Some(ref json) = s.available_commands_json {
+                        let escaped = webview_utils::escape_js_template(json);
+                        let _ = sidebar_wv.evaluate_script(&format!(
+                            "window.__setAvailableCommands && window.__setAvailableCommands({sid},`{escaped}`)"
+                        ));
+                    }
+                    if !s.messages.is_empty() {
+                        if let Ok(msgs_json) = serde_json::to_string(&s.messages) {
+                            let _ = sidebar_wv.evaluate_script(&format!(
+                                "window.__replayMessages && window.__replayMessages({sid},{msgs_json})"
+                            ));
+                        }
+                    }
+                }
+                // Strip the JS placeholder sid=1 if persisted history doesn't
+                // include it (user closed it before quitting last session).
+                if !rust_has_sid1 {
+                    let _ = sidebar_wv.evaluate_script(
+                        "window.__removeSession && window.__removeSession(1)"
+                    );
+                }
+                let active = active_session_id;
+                let _ = sidebar_wv.evaluate_script(&format!(
+                    "window.__switchSession && window.__switchSession({active})"
+                ));
             }
 
             // ── Ask AI: open sidebar + inject prompt ──────────────────────
@@ -3888,7 +4143,16 @@ fn main() {
             // ── Quit ──────────────────────────────────────────────────────
             Event::UserEvent(AppEvent::Quit) => {
                 crash_report::log_exit_trigger("Quit");
-                save_and_exit(&tabs, &favicon_cache, &prompt_history, &ai_prompt_history, control_flow);
+                save_and_exit(
+                    &tabs,
+                    &favicon_cache,
+                    &prompt_history,
+                    &ai_prompt_history,
+                    &sessions,
+                    active_session_id,
+                    cfg.max_acp_session_messages,
+                    control_flow,
+                );
             }
 
             // ── Title update ──────────────────────────────────────────────
@@ -4424,7 +4688,16 @@ fn main() {
                 WindowEvent::CloseRequested => {
                     if window_id == browser_win_id {
                         crash_report::log_exit_trigger("CloseRequested");
-                        save_and_exit(&tabs, &favicon_cache, &prompt_history, &ai_prompt_history, control_flow);
+                        save_and_exit(
+                            &tabs,
+                            &favicon_cache,
+                            &prompt_history,
+                            &ai_prompt_history,
+                            &sessions,
+                            active_session_id,
+                            cfg.max_acp_session_messages,
+                            control_flow,
+                        );
                     } else if window_id == chrome_win_id {
                         // Chrome window should not be closed independently — ignore.
                     } else {
@@ -5007,12 +5280,55 @@ fn build_learning_prompt(
     Some(out)
 }
 
+/// Append a message to a session's persisted log, stamping it with the
+/// current wall-clock time. Cheap — caller is expected to call
+/// `persist_acp_history` afterwards (debounced via thread spawn).
+fn push_acp_msg(s: &mut AcpSession, role: &str, text: String) {
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    s.messages.push(config::AcpMessage {
+        role: role.to_string(),
+        text,
+        ts,
+    });
+}
+
+/// Snapshot every ACP session into `AcpHistory` and dispatch the JSON write
+/// on a background thread. Mirrors `save_ai_prompt_history` — fire-and-forget,
+/// errors are logged but never block the event loop. Caps each session's
+/// message log at `max_msgs` (oldest dropped first).
+fn persist_acp_history(sessions: &[AcpSession], active_id: u64, max_msgs: usize) {
+    let snap_sessions: Vec<config::AcpSessionSnapshot> = sessions
+        .iter()
+        .map(|s| {
+            let start = s.messages.len().saturating_sub(max_msgs);
+            config::AcpSessionSnapshot {
+                id: s.id,
+                title: s.title.clone(),
+                tag: s.tag.clone(),
+                acp_session_id: s.acp_session_id.clone(),
+                messages: s.messages[start..].to_vec(),
+            }
+        })
+        .collect();
+    let history = config::AcpHistory {
+        sessions: snap_sessions,
+        active_id,
+    };
+    std::thread::spawn(move || config::save_acp_history(&history));
+}
+
 /// Save session state and exit the event loop.
 fn save_and_exit(
     tabs: &Arc<Mutex<browser::TabManager>>,
     favicon_cache: &std::collections::HashMap<String, String>,
     prompt_history: &[String],
     ai_prompt_history: &[String],
+    acp_sessions: &[AcpSession],
+    acp_active_id: u64,
+    max_acp_session_messages: usize,
     control_flow: &mut ControlFlow,
 ) {
     let mut tm = tabs.lock().unwrap();
@@ -5035,6 +5351,25 @@ fn save_and_exit(
     config::save_history(tm.history());
     config::save_prompt_history(prompt_history);
     config::save_ai_prompt_history(ai_prompt_history);
+    // Synchronous final save so the ACP log is durable across cold restart
+    // even if the OS reaps background threads on app exit.
+    let acp_history = config::AcpHistory {
+        sessions: acp_sessions
+            .iter()
+            .map(|s| {
+                let start = s.messages.len().saturating_sub(max_acp_session_messages);
+                config::AcpSessionSnapshot {
+                    id: s.id,
+                    title: s.title.clone(),
+                    tag: s.tag.clone(),
+                    acp_session_id: s.acp_session_id.clone(),
+                    messages: s.messages[start..].to_vec(),
+                }
+            })
+            .collect(),
+        active_id: acp_active_id,
+    };
+    config::save_acp_history(&acp_history);
     drop(tm);
     crash_report::log_clean_shutdown();
     *control_flow = ControlFlow::Exit;

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,6 +316,14 @@ fn main() {
     let chrome_win = Arc::new(chrome_win);
     let chrome_win_id = chrome_win.id();
 
+    // Resign chrome_win's key status whenever the app deactivates. Without this,
+    // borderless child windows can hold key status across Cmd+Tab / app switch,
+    // routing keys (e.g. Enter pressed in Slack) back to our sidebar WebView
+    // and pulling octoweb back to the front.
+    unsafe {
+        macos::install_resign_key_on_deactivate(chrome_win.ns_window());
+    }
+
     // ── Browser WebView factory ───────────────────────────────────────────
     // Each tab gets its own WebView (build_as_child). Hide/show to switch —
     // no reload, full state (scroll, video, JS) preserved.

--- a/src/sidebar_html.rs
+++ b/src/sidebar_html.rs
@@ -3004,26 +3004,17 @@ pub fn html() -> String {
     }
   });
   input.addEventListener('keydown', e => {
-    // Ctrl+J → insert newline (alias for Shift+Enter). On macOS WKWebView
-    // the NSResponder Emacs binding rewrites Ctrl+J to "insertNewline:" so
-    // e.key arrives as 'Enter' (not 'j'); match by e.code to be reliable.
-    // Must run BEFORE the plain-Enter branch so we don't fall through to send().
-    const isCtrlJ = e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey
-      && (e.code === 'KeyJ' || e.key === 'j' || e.key === 'J');
-    if (isCtrlJ) {
+    // Send only on plain Enter (no modifiers). Shift+Enter inserts a newline
+    // natively in <textarea>; Ctrl+J is translated by AppKit to
+    // `insertLineBreak:` which also inserts \n natively — we must NOT consume
+    // it here. Excluding all modifier-keyed Enters makes both work identically
+    // even if AppKit synthesizes an Enter keydown from Ctrl+J on some macOS
+    // versions (in which case e.ctrlKey is still true and we let it through).
+    if (e.key === 'Enter' && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey && !_ph.isInSearchMode()) {
       e.preventDefault();
-      // Use execCommand to mirror Shift+Enter exactly — preserves undo stack
-      // and triggers native input events, unlike manual value mutation.
-      if (!document.execCommand('insertText', false, '\n')) {
-        const start = input.selectionStart;
-        const end = input.selectionEnd;
-        input.value = input.value.slice(0, start) + '\n' + input.value.slice(end);
-        input.selectionStart = input.selectionEnd = start + 1;
-        input.dispatchEvent(new Event('input', { bubbles: true }));
-      }
-      return;
+      send();
+      _ph.resetState();
     }
-    if (e.key === 'Enter' && !e.shiftKey && !_ph.isInSearchMode()) { e.preventDefault(); send(); _ph.resetState(); return; }
   });
   input.addEventListener('input', () => {
     input.style.height = 'auto';

--- a/src/sidebar_html.rs
+++ b/src/sidebar_html.rs
@@ -3004,13 +3004,22 @@ pub fn html() -> String {
     }
   });
   input.addEventListener('keydown', e => {
-    // Send only on plain Enter (no modifiers). Shift+Enter inserts a newline
-    // natively in <textarea>; Ctrl+J is translated by AppKit to
-    // `insertLineBreak:` which also inserts \n natively — we must NOT consume
-    // it here. Excluding all modifier-keyed Enters makes both work identically
-    // even if AppKit synthesizes an Enter keydown from Ctrl+J on some macOS
-    // versions (in which case e.ctrlKey is still true and we let it through).
-    if (e.key === 'Enter' && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey && !_ph.isInSearchMode()) {
+    if (_ph.isInSearchMode()) return;
+    // Ctrl+J → insert newline at caret. execCommand('insertText') is the same
+    // path WKWebView uses for Shift+Enter — preserves focus, caret, undo,
+    // scroll, and fires the 'input' event for auto-resize.
+    if (e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && (e.key === 'j' || e.key === 'J' || e.code === 'KeyJ')) {
+      e.preventDefault();
+      document.execCommand('insertText', false, '\n');
+      // Browsers under-measure a trailing "\n" in scrollHeight, so the caret
+      // line ends up clipped after auto-resize. Pin the textarea scroll to
+      // the caret so the new empty line stays visible — Shift+Enter gets
+      // this for free via the native text view path.
+      input.scrollTop = input.scrollHeight;
+      return;
+    }
+    // Plain Enter sends. Shift+Enter falls through → native newline.
+    if (e.key === 'Enter' && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
       e.preventDefault();
       send();
       _ph.resetState();

--- a/src/sidebar_html.rs
+++ b/src/sidebar_html.rs
@@ -3004,18 +3004,26 @@ pub fn html() -> String {
     }
   });
   input.addEventListener('keydown', e => {
-    if (e.key === 'Enter' && !e.shiftKey && !_ph.isInSearchMode()) { e.preventDefault(); send(); _ph.resetState(); return; }
-    // Ctrl+J → insert newline (alias for Shift+Enter). Browsers don't
-    // produce a newline natively for this combo in textareas, so do it manually.
-    if (e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && (e.key === 'j' || e.key === 'J')) {
+    // Ctrl+J → insert newline (alias for Shift+Enter). On macOS WKWebView
+    // the NSResponder Emacs binding rewrites Ctrl+J to "insertNewline:" so
+    // e.key arrives as 'Enter' (not 'j'); match by e.code to be reliable.
+    // Must run BEFORE the plain-Enter branch so we don't fall through to send().
+    const isCtrlJ = e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey
+      && (e.code === 'KeyJ' || e.key === 'j' || e.key === 'J');
+    if (isCtrlJ) {
       e.preventDefault();
-      const start = input.selectionStart;
-      const end = input.selectionEnd;
-      input.value = input.value.slice(0, start) + '\n' + input.value.slice(end);
-      input.selectionStart = input.selectionEnd = start + 1;
-      input.dispatchEvent(new Event('input', { bubbles: true }));
+      // Use execCommand to mirror Shift+Enter exactly — preserves undo stack
+      // and triggers native input events, unlike manual value mutation.
+      if (!document.execCommand('insertText', false, '\n')) {
+        const start = input.selectionStart;
+        const end = input.selectionEnd;
+        input.value = input.value.slice(0, start) + '\n' + input.value.slice(end);
+        input.selectionStart = input.selectionEnd = start + 1;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+      }
       return;
     }
+    if (e.key === 'Enter' && !e.shiftKey && !_ph.isInSearchMode()) { e.preventDefault(); send(); _ph.resetState(); return; }
   });
   input.addEventListener('input', () => {
     input.style.height = 'auto';

--- a/src/sidebar_html.rs
+++ b/src/sidebar_html.rs
@@ -2066,11 +2066,19 @@ pub fn html() -> String {
   // ── Bootstrap default session (sid=1, matches main.rs) ──────────────────
   // The main.rs spawns a default session (id=1, "Assistant", "octoweb:assistant")
   // before the sidebar HTML loads. We register it here so events arriving with
-  // sid=1 find a target.
+  // sid=1 find a target. If Rust restored persisted sessions from disk, it
+  // will push __addSession / __renameSession / __replayMessages on
+  // `sidebar_ready` to override this default.
   (function initDefault() {
     window.__addSession(1, 'Assistant', 'octoweb:assistant', 'connecting');
     switchTo(1);
   })();
+
+  // Tell Rust the JS layer is initialized. Rust uses this signal to push
+  // persisted-session restore (additional sessions, renamed titles, replayed
+  // messages, last-active session). Fires once per sidebar webview lifetime
+  // (the webview survives toggle visibility — JS state is not re-run).
+  window.ipc.postMessage(JSON.stringify({ type: 'sidebar_ready' }));
 
   // ── Clear current session (toolbar pencil button) ───────────────────────
   newSessBtn.addEventListener('click', () => {
@@ -2671,6 +2679,31 @@ pub fn html() -> String {
     if (!s) return;
     window.__setThinking(sid, false);
     appendMessage(s, 'error', text);
+  };
+
+  // Replay persisted messages on cold-start. Rust calls this once per session
+  // on sidebar bootstrap with the full message log restored from disk.
+  // Each entry: { role: 'user'|'agent'|'error', text: string, ts?: number }.
+  // Skips toolDetails/images — those aren't persisted (live-only).
+  window.__replayMessages = function(sid, msgs) {
+    const s = sessions.get(sid);
+    if (!s || !Array.isArray(msgs) || msgs.length === 0) return;
+    for (let i = 0; i < msgs.length; i++) {
+      const m = msgs[i];
+      const role = m && m.role;
+      const text = (m && typeof m.text === 'string') ? m.text : '';
+      if (role === 'user' || role === 'error') {
+        appendMessage(s, role, text);
+      } else if (role === 'agent') {
+        const bubble = startAgentBubble(s);
+        if (!bubble) continue;
+        const cmdObj = tryParseCommandJson(text);
+        bubble.innerHTML = cmdObj ? renderCommandOutput(cmdObj) : renderMd(text);
+        // 0 tools, empty details — replay never carries tool history.
+        finishAgentBubble(s, bubble, text, 0, []);
+      }
+    }
+    if (sid === activeSid) { updateWelcome(); scrollToBottom(); }
   };
 
   function scrollToBottom() {


### PR DESCRIPTION
- Add AcpHistory and AcpSessionSnapshot for session state management
- Implement atomic disk persistence for chat message logs
- Restore agent conversation context via session ID resumption
- Add JS interface to replay persisted message logs on startup
- Signal sidebar readiness via sidebar_ready IPC message
- Restore session metadata including IDs, titles, and active state
- Cache available commands to ensure UI consistency
- Add configuration to cap maximum messages per session