### PR TITLE
feat(sandbox): confine agent filesystem access to workspace

### DIFF
--- a/src/a2ui_render_ui.rs
+++ b/src/a2ui_render_ui.rs
@@ -75,7 +75,7 @@ if [[ "$msg_count" == "0" ]]; then
   exit 1
 fi
 
-queue="${HOME}/.local/share/a2ui"
+queue="${HOME}/.local/share/octoweb/a2ui"
 mkdir -p "$queue"
 
 rand_hex=$(od -An -N3 -tx1 /dev/urandom | tr -d ' \n')
@@ -122,23 +122,32 @@ while :; do
 done
 "####;
 
-/// Where the script lives. Octomind is spawned with CWD = `dirs::home_dir()`
-/// (acp.rs), so `<home>/.agents/tools/` is where it'll be discovered.
-pub fn tool_path() -> PathBuf {
+/// Octoweb's internal data root, and the cwd + `--sandbox` root the agent
+/// runs inside (set in acp.rs). Everything the agent can touch lives under
+/// here, so its writes can't escape into the user's home. Derived from
+/// `~/.local/share` to match the project's existing XDG-style layout.
+pub fn workspace_dir() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join(".local")
+        .join("share")
+        .join("octoweb")
+}
+
+/// Where the script lives. Octomind discovers local tools at
+/// `<cwd>/.agents/tools/*`, and cwd is `workspace_dir()`.
+pub fn tool_path() -> PathBuf {
+    workspace_dir()
         .join(".agents")
         .join("tools")
         .join("render_ui")
 }
 
 /// Queue directory the script writes envelopes into. Watcher polls this.
+/// Lives inside `workspace_dir()` so `--sandbox` doesn't block the script's
+/// writes.
 pub fn queue_dir() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join(".local")
-        .join("share")
-        .join("a2ui")
+    workspace_dir().join("a2ui")
 }
 
 /// Idempotent install — writes the script if absent or content drifted, sets

--- a/src/a2ui_watcher.rs
+++ b/src/a2ui_watcher.rs
@@ -1,4 +1,4 @@
-/// Polls `~/.local/share/a2ui/` for envelope files written by the
+/// Polls `~/.local/share/octoweb/a2ui/` for envelope files written by the
 /// `render_ui` tool. Emits one snapshot per unique (id, status) transition
 /// onto the tao event-loop proxy as `AppEvent::A2uiUpdate`.
 ///

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -269,7 +269,11 @@ impl AcpHandle {
             .next()
             .ok_or_else(|| anyhow::anyhow!("empty agent command"))?
             .to_string();
-        let args: Vec<String> = parts.map(str::to_string).collect();
+        let mut args: Vec<String> = parts.map(str::to_string).collect();
+        // Sandbox every agent to its workspace cwd (set in init_session) so its
+        // filesystem writes can't escape octoweb's internal dir. Injected here,
+        // centrally, instead of at each `octomind acp …` call site.
+        args.push("--sandbox".to_string());
 
         // Spawn a dedicated OS thread with a current_thread runtime + LocalSet.
         // ClientSideConnection is !Send, so it must live entirely on one thread.
@@ -336,11 +340,17 @@ async fn init_session(
     program: String,
     args: Vec<String>,
 ) -> anyhow::Result<()> {
+    // Run the agent inside octoweb's internal workspace dir (not the user's
+    // home). Combined with `--sandbox` (injected in `connect`), this confines
+    // all of the agent's filesystem writes to this dir.
+    let workspace = crate::a2ui_render_ui::workspace_dir();
+    let _ = std::fs::create_dir_all(&workspace);
+
     let mut child = tokio::process::Command::new(&program)
         .args(&args)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .current_dir(dirs::home_dir().unwrap_or_else(|| "/".into()))
+        .current_dir(&workspace)
         .kill_on_drop(true)
         .spawn()?;
 
@@ -392,14 +402,11 @@ async fn init_session(
     .await?;
 
     // Workspace cwd for the session — octomind uses this to discover local
-    // tools at `<cwd>/.agents/tools/*`. When octoweb is launched as a .app
-    // bundle via launchd, `std::env::current_dir()` is `/` (not the user's
-    // home), which breaks local-tool discovery. Pin to the user's home dir
-    // so it matches where we install `render_ui`.
+    // tools at `<cwd>/.agents/tools/*` and as the `--sandbox` root. Must match
+    // the process cwd set above so tool discovery and the sandbox agree, and so
+    // it survives launchd launches where `current_dir()` would be `/`.
     let resp = conn
-        .new_session(acp::NewSessionRequest::new(
-            dirs::home_dir().unwrap_or_else(|| "/".into()),
-        ))
+        .new_session(acp::NewSessionRequest::new(workspace.clone()))
         .await?;
 
     let session_id = resp.session_id;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1616,8 +1616,8 @@ fn main() {
     };
 
     // ── A2UI ────────────────────────────────────────────────────────────────
-    // Ship the `render_ui` tool into `~/.agents/tools/` so any octomind
-    // subprocess we spawn (CWD = home) auto-discovers it. Then start a
+    // Ship the `render_ui` tool into `<workspace>/.agents/tools/` so any
+    // octomind subprocess we spawn (CWD = workspace) auto-discovers it. Then start a
     // background watcher on the envelope queue dir; every status transition
     // becomes an `A2uiUpdate` event the active session renders inline.
     match a2ui_render_ui::install() {


### PR DESCRIPTION
- Introduce workspace_dir to manage internal data root
- Inject --sandbox flag into agent commands
- Set agent process current working directory to workspace
- Relocate render_ui tool and queue to workspace directory
- Update session initialization to use workspace path